### PR TITLE
upgrade debian 13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 RUN apt-get update && apt-get install libssl-dev build-essential cmake -y
 RUN cargo build --release
 
-FROM debian:12
+FROM debian:13
 RUN apt-get update && apt-get install libssl3 ca-certificates -y
 RUN update-ca-certificates
 WORKDIR /app/ckb-discovery

--- a/exposed/Dockerfile
+++ b/exposed/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 RUN cd /usr/src/ckb-discovery/exposed
 RUN cargo build -p exposed --release
 
-FROM debian:12
+FROM debian:13
 RUN apt-get update && apt-get install libssl3 -y
 WORKDIR /app/exposed
 COPY --from=build /usr/src/ckb-discovery/target/release/exposed /app/exposed

--- a/marci/Dockerfile
+++ b/marci/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install libssl-dev build-essential cmake -y
 RUN cd /usr/src/ckb-discovery/
 RUN cargo build -p marci --release
 
-FROM debian:12
+FROM debian:13
 RUN apt-get update && apt-get install libssl3 ca-certificates -y && update-ca-certificates
 WORKDIR /app/marci
 COPY --from=build /usr/src/ckb-discovery/target/release/marci /app/marci


### PR DESCRIPTION
The binary compiled with Rust 1.93 fails to run on Debian 12, reporting the error: `/app/marci/marci: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /app/marci/marci)` Requires upgrading to Debian 